### PR TITLE
perf: 修改默认语言设置为简体中文

### DIFF
--- a/src/service/settings.ts
+++ b/src/service/settings.ts
@@ -1,10 +1,10 @@
-import channel from './channel';
-import { ChannelEventHandler } from '../util/types';
 import {
     RMG_RUNTIME_ALLOW_ANALYTICS_KEY,
     RMG_RUNTIME_COLOUR_MODE_KEY,
     RMG_RUNTIME_LANGUAGE_KEY,
 } from '../util/constant';
+import { ChannelEventHandler } from '../util/types';
+import channel from './channel';
 import eventLogger from './event-logger';
 
 const SET_LANGUAGE = 'SET_LANGUAGE';
@@ -16,7 +16,7 @@ const setLanguage = (value: string) => {
 };
 
 const getLanguage = () => {
-    return window.localStorage.getItem(RMG_RUNTIME_LANGUAGE_KEY) || 'en';
+    return window.localStorage.getItem(RMG_RUNTIME_LANGUAGE_KEY) || 'zh-Hans';
 };
 
 const onLanguageChange = (callback: ChannelEventHandler<string>) => {


### PR DESCRIPTION
- 将 getLanguage 函数的默认返回值从 'en' 改为 'zh-Hans'
- 优化了代码导入顺序，提高代码可读性