### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -3,6 +3,9 @@ name: Code Quality Check
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   check:
 


### PR DESCRIPTION
Potential fix for [https://github.com/railmapgen/rmg-runtime/security/code-scanning/1](https://github.com/railmapgen/rmg-runtime/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/code-check.yml` so the workflow does not inherit potentially broad defaults.  
Best fix here (without changing behavior): set workflow-level permissions to read-only for repository contents.

- **File to change:** `.github/workflows/code-check.yml`
- **Region to change:** near the top-level keys, after `on:` and before `jobs:`
- **Change:** add:
  ```yml
  permissions:
    contents: read
  ```
This is sufficient for `actions/checkout` and typical lint/test runs that do not need write scopes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
